### PR TITLE
Replace Lightly -> Darkly

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -308,7 +308,7 @@ For detailed further instructions, please refer to [ArchWiki](https://wiki.archl
 - [kwin-gestures](https://github.com/taj-ny/kwin-gestures) — custom kwin touchpad gestures for Plasma 6
 - [kde-thumbnailer-apk](https://github.com/z3ntu/kde-thumbnailer-apk) — you got it right; Android's .apk thumbnails
 - [klassy](https://github.com/paulmcauley/klassy) — custom window decoration, application style and global theme
-- [lightly-qt](https://github.com/Luwx/Lightly) — a modern style for qt applications 
+- [darkly](https://github.com/Bali10050/Darkly) — a modern style for qt applications 
 
 ### Administration
 


### PR DESCRIPTION
Lightly has been unmaintained for a long time, and the original version doesn't work with Plasma 6.x. This fork of lightly (Darkly) has been maintained for a while, and it also brings in support for plasma 6 and some enhancements from the original.