### PR TITLE
Add KDoit, lightweight to-do plasmoid for KDE Plasma 6

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -389,6 +389,7 @@ If you find this repo useful, you might want to see the work of these people as 
 - [chat-qt](https://github.com/DenysMb/ChatQT-Plasmoid) <sup>`no packages avaiable`</sup> - chat with ollama models directly from taskbar
 
 - [apdatifier](https://github.com/exequtic/apdatifier) <sup>`no packages avaiable`</sup> - applet for managing Arch Linux updates (including AUR)
+- [kdoit](https://github.com/lubdhak7414/KDoit) <sup>`no packages avaiable`</sup> - lightweight to-do widget for KDE Plasma 6 with nested sublists, priorities, due dates, and UUID-based sync
     - *Depends on*: `pacman-contrib` `curl` `jq` `unzip` `tar` `fzf`
 
 #### Misc


### PR DESCRIPTION
## What is KDoit?

KDoit is a lightweight to-do list widget for KDE Plasma 6, written in pure QML with no build step.

Features:
- Nested sublists, priorities, due dates, and categories
- Drag-and-drop reorder and multi-select
- UUID-based sync across machines (Syncthing, Nextcloud, etc.)
- Markdown export (Obsidian Tasks compatible) and iCalendar export
- No account, no cloud -- tasks live in ~/.local/share/kdoit/tasks.json

Install:
```bash
git clone https://github.com/lubdhak7414/KDoit.git
kpackagetool6 -t Plasma/Applet -i KDoit/
```